### PR TITLE
Updated background image link

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,7 +40,7 @@ module.exports = {
       },
       backgroundImage: {
         'hero-pattern':
-          "url('https://i.ibb.co/MkvLDfb/Rectangle-4389.png')",
+          "url('https://demos.wrappixel.com/premium-admin-templates/react/flexy-react/main/static/media/welcome-bg-2x-svg.25338f53.svg')",
       },
     },
   },


### PR DESCRIPTION
The link of the background image in the Earnings div on the Ecommerce page was no longer valid and doesn't resolve to an image. I copied the current link in the live project at shoppy-dashboard.vercel.app and replaced it with it. Now the background image shows.